### PR TITLE
Add `elab-stlc-letrec`

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -18,6 +18,7 @@
 (package (name elab-stlc-abstract))
 (package (name elab-stlc-bidirectional))
 (package (name elab-stlc-unification))
+(package (name elab-stlc-letrec))
 (package (name elab-variant-unification))
 (package (name elab-record-patching))
 

--- a/elab-stlc-letrec/Core.ml
+++ b/elab-stlc-letrec/Core.ml
@@ -1,0 +1,408 @@
+(** {0 Core language} *)
+
+(** {1 Names} *)
+
+(** These names are used as hints for pretty printing binders and variables,
+    but don’t impact the equality of terms. *)
+type name = string
+
+
+(** {1 Nameless binding structure} *)
+
+(** The binding structure of terms is represented in the core language by
+    using numbers that represent the distance to a binder, instead of by the
+    names attached to those binders. *)
+
+(** {i De Bruijn index} that represents a variable occurance by the number of
+    binders between the occurance and the binder it refers to. *)
+type index = int
+
+(** {i De Bruijn level} that represents a variable occurance by the number of
+    binders from the top of the environment to the binder that the ocurrance
+    refers to. These do not change their meaning as new bindings are added to
+    the environment. *)
+type level = int
+
+(** Converts a {!level} to an {!index} that is bound in an environment of the
+    supplied size. Assumes that [ size > level ]. *)
+let level_to_index size level =
+  size - level - 1
+
+(** An environment of bindings that can be looked up directly using a
+    {!index}, or by inverting a {!level} using {!level_to_index}. *)
+type 'a env = 'a list
+
+
+(** {1 Syntax} *)
+
+(** Metavariable identifier *)
+type meta_id = int
+
+(** Type syntax *)
+type ty =
+  | BoolType
+  | IntType
+  | FunType of ty * ty
+  | MetaVar of meta_state ref
+
+(** The state of a metavariable, updated during unification *)
+and meta_state =
+  | Solved of ty
+  | Unsolved of meta_id
+
+(** Primitive operations *)
+type prim = [
+  | `Eq   (** [Int -> Int -> Bool] *)
+  | `Add  (** [Int -> Int -> Int] *)
+  | `Sub  (** [Int -> Int -> Int] *)
+  | `Mul  (** [Int -> Int -> Int] *)
+  | `Neg  (** [Int -> Int] *)
+]
+
+(** Term syntax *)
+
+(*
+`fix` binds several mutually recursive functions.
+The RHS of each binding is always a FunLit.
+fix
+  f1 = fun(x1: t1) => e1;
+  ...
+  fn = fun(xn: tn) => en;
+in e
+*)
+
+type tm =
+  | Var of index
+  | Let of name * ty * tm * tm
+  | Fix of (name * ty * tm) list * tm
+  | BoolLit of bool
+  | BoolElim of tm * tm * tm
+  | IntLit of int
+  | FunLit of name * ty * tm
+  | FunApp of tm * tm
+  | PrimApp of prim * tm list
+
+
+module Semantics = struct
+
+  (** {1 Values} *)
+
+  type vtm =
+    | Neu of ntm
+    | BoolLit of bool
+    | IntLit of int
+    | FunLit of name * ty * (vtm -> vtm)
+
+  and ntm =
+    | Var of level
+    | BoolElim of ntm * vtm Lazy.t * vtm Lazy.t
+    | FunApp of ntm * vtm
+    | PrimApp of prim * vtm list
+
+
+  (** {1 Eliminators} *)
+
+  let bool_elim head vtm0 vtm1 =
+    match head with
+    | Neu ntm -> Neu (BoolElim (ntm, vtm0, vtm1))
+    | BoolLit true -> Lazy.force vtm0
+    | BoolLit false -> Lazy.force vtm1
+    | _ -> invalid_arg "expected boolean"
+
+  let prim_app prim args =
+    match prim, args with
+    | `Eq, [IntLit t1; IntLit t2] -> BoolLit (t1 = t2)
+    | `Add, [IntLit t1; IntLit t2] -> IntLit (t1 + t2)
+    | `Sub, [IntLit t1; IntLit t2] -> IntLit (t1 - t2)
+    | `Mul, [IntLit t1; IntLit t2] -> IntLit (t1 * t2)
+    | `Neg, [IntLit t1] -> IntLit (-t1)
+    | prim, args -> Neu (PrimApp (prim, args))
+
+  let fun_app head arg =
+    match head with
+    | Neu ntm -> Neu (FunApp (ntm, arg))
+    | FunLit (_, _, body) -> body arg
+    | _ -> invalid_arg "expected function"
+
+
+  (** {1 Evaluation} *)
+
+  (** Evaluate a term from the syntax into its semantic interpretation *)
+  let rec eval (env : vtm env) (tm : tm) : vtm =
+    match tm with
+    | Var index -> List.nth env index
+    | Let (_, _, def, body) ->
+        let def = eval env def in
+        eval (def :: env) body
+    | Fix ([], _) -> failwith "impossible"
+    | Fix ([_, _, rhs], body) ->
+        let (name, ty, fun_body) = match rhs with
+          | FunLit (name, ty, fun_body) ->(name, ty, fun_body)
+          | _ -> failwith "impossible"
+        in
+        let rec env' = (FunLit(name, ty, fun arg -> eval (arg :: env') fun_body)) :: env in
+        eval env' body
+    | Fix (_, _) -> failwith "TODO"
+    | BoolLit b -> BoolLit b
+    | BoolElim (head, tm0, tm1) ->
+        let head = eval env head in
+        let vtm0 = Lazy.from_fun (fun () -> eval env tm0) in
+        let vtm1 = Lazy.from_fun (fun () -> eval env tm1) in
+        bool_elim head vtm0 vtm1
+    | IntLit i -> IntLit i
+    | PrimApp (prim, args) ->
+        prim_app prim (List.map (eval env) args)
+    | FunLit (name, param_ty, body) ->
+        FunLit (name, param_ty, fun arg -> eval (arg :: env) body)
+    | FunApp (head, arg) ->
+        let head = eval env head in
+        let arg = eval env arg in
+        fun_app head arg
+
+
+  (** {1 Quotation} *)
+
+  (** Convert terms from the semantic domain back into syntax. *)
+  let rec quote (size : int) (vtm : vtm) : tm =
+    match vtm with
+    | Neu ntm -> quote_neu size ntm
+    | BoolLit b -> BoolLit b
+    | IntLit i -> IntLit i
+    | FunLit (name, param_ty, body) ->
+        let body = quote (size + 1) (body (Neu (Var size))) in
+        FunLit (name, param_ty, body)
+
+  and quote_neu (size : int) (ntm : ntm) : tm =
+    match ntm with
+    | Var level -> Var (level_to_index size level)
+    | BoolElim (head, vtm0, vtm1) ->
+        let tm0 = quote size (Lazy.force vtm0) in
+        let tm1 = quote size (Lazy.force vtm1) in
+        BoolElim (quote_neu size head, tm0, tm1)
+    | FunApp (head, arg) -> FunApp (quote_neu size head, quote size arg)
+    | PrimApp (prim, args) -> PrimApp (prim, List.map (quote size) args)
+
+  (** {1 Normalisation} *)
+
+  (** By evaluating a term then quoting the result, we can produce a term that
+      is reduced as much as possible in the current environment. *)
+  let normalise (env : vtm list) (tm : tm) : tm =
+    quote (List.length env) (eval env tm)
+
+end
+
+
+(** {1 Functions related to metavariables} *)
+
+(** Create a fresh, unsolved metavariable *)
+let fresh_meta : unit -> meta_state ref =
+  let next_id = ref 0 in
+  fun () ->
+    let id = !next_id in
+    incr next_id;
+    ref (Unsolved id)
+
+(** Force any solved metavariables on the outermost part of a type. Chains of
+    metavariables will be collapsed to make forcing faster in the future. This
+    is sometimes referred to as {i path compression}. *)
+let rec force (ty : ty) : ty =
+  match ty with
+  | MetaVar m as ty -> begin
+      match !m with
+      | Solved ty ->
+          let ty = force ty in
+          m := Solved ty;
+          ty
+      | Unsolved _ -> ty
+  end
+  | ty -> ty
+
+
+(** {1 Unification} *)
+
+exception InfiniteType of meta_id
+exception MismatchedTypes of ty * ty
+
+(** Occurs check. This guards against self-referential unification problems
+    that would result in infinite loops during unification. *)
+let rec occurs (id : meta_id) (ty : ty) : unit =
+  match force ty with
+  | MetaVar m -> begin
+      match !m with
+      | Unsolved id' when id = id' ->
+          raise (InfiniteType id)
+      | Unsolved _ | Solved _-> ()
+  end
+  | BoolType -> ()
+  | IntType -> ()
+  | FunType (param_ty, body_ty) ->
+      occurs id param_ty;
+      occurs id body_ty
+
+(** Check if two types are the same, updating unsolved metavaribles in one
+    type with known information from the other type if possible. *)
+let rec unify (ty0 : ty) (ty1 : ty) : unit =
+  match force ty0, force ty1 with
+  | ty0, ty1 when ty0 = ty1 -> ()
+  | MetaVar m, ty | ty, MetaVar m -> unify_meta m ty
+  | BoolType, BoolType -> ()
+  | IntType, IntType -> ()
+  | FunType (param_ty0, body_ty0), FunType (param_ty1, body_ty1) ->
+      unify param_ty0 param_ty1;
+      unify body_ty0 body_ty1;
+  | ty1, ty2 ->
+      raise (MismatchedTypes (ty1, ty2))
+
+(** Unify a metavariable with a type *)
+and unify_meta (m : meta_state ref) (ty : ty) : unit =
+  match !m with
+  | Unsolved id ->
+      occurs id ty;
+      m := Solved ty;
+  | Solved mty ->
+      unify ty mty
+
+
+(** {1 Zonking} *)
+
+(** These functions flatten solved metavariables in types. This is imporatant
+    for pretty printing types, as we want to be able to ‘see through’
+    metavariables to properly associate function types. *)
+
+let rec zonk_ty (ty : ty) : ty =
+  match force ty with
+  | BoolType -> BoolType
+  | IntType -> IntType
+  | FunType (param_ty, body_ty) ->
+      FunType (zonk_ty param_ty, zonk_ty body_ty)
+  | MetaVar _ as ty -> ty
+
+let rec zonk_tm (tm : tm) : tm =
+  match tm with
+  | Var index -> Var index
+  | Let (name, def_ty, def, body) ->
+      Let (name, zonk_ty def_ty, zonk_tm def, zonk_tm body)
+  | Fix (funs, body) ->
+      let zonk_fun = fun (name, ty, tm) -> (name, zonk_ty ty, zonk_tm tm) in
+      Fix (List.map zonk_fun funs, zonk_tm body)
+  | BoolLit b -> BoolLit b
+  | BoolElim (head, tm0, tm1) ->
+      BoolElim (zonk_tm head, zonk_tm tm0, zonk_tm tm1)
+  | IntLit i -> IntLit i
+  | PrimApp (prim, args) ->
+      PrimApp (prim, List.map zonk_tm args)
+  | FunLit (name, param_ty, body) ->
+      FunLit (name, zonk_ty param_ty, zonk_tm body)
+  | FunApp (head, arg) ->
+      FunApp (zonk_tm head, zonk_tm arg)
+
+
+(** {1 Pretty printing} *)
+
+let rec pp_ty (fmt : Format.formatter) (ty : ty) : unit =
+  match ty with
+  | FunType (param_ty, body_ty) ->
+      Format.fprintf fmt "%a -> %a"
+        pp_atomic_ty param_ty
+        pp_ty body_ty
+  | ty ->
+      pp_atomic_ty fmt ty
+and pp_atomic_ty fmt ty =
+  match ty with
+  | BoolType -> Format.fprintf fmt "Bool"
+  | IntType -> Format.fprintf fmt "Int"
+  | MetaVar m -> begin
+      match !m with
+      | Solved ty -> pp_atomic_ty fmt ty
+      | Unsolved id -> Format.fprintf fmt "?%i" id
+  end
+  | ty -> Format.fprintf fmt "@[(%a)@]" pp_ty ty
+
+let pp_name_ann fmt (name, ty) =
+  Format.fprintf fmt "@[<2>@[%s :@]@ %a@]" name pp_ty ty
+
+let pp_param fmt (name, ty) =
+  Format.fprintf fmt "@[<2>(@[%s :@]@ %a)@]" name pp_ty ty
+
+let rec pp_tm (names : name env) (fmt : Format.formatter) (tm : tm) : unit =
+  match tm with
+  | Let _ as tm ->
+      let rec go names fmt tm =
+        match tm with
+        | Let (name, def_ty, def, body) ->
+            Format.fprintf fmt "@[<2>@[let %a@ :=@]@ @[%a;@]@]@ %a"
+              pp_name_ann (name, def_ty)
+              (pp_tm names) def
+              (go (name :: names)) body
+        | tm -> Format.fprintf fmt "@[%a@]" (pp_tm names) tm
+      in
+      Format.fprintf fmt "@[<hv>%a@]" (go names) tm
+  | Fix(funs, body) ->
+      let names = List.append names (ListLabels.map funs ~f:(fun (name, _, _) -> name)) in
+      let pp_fun fmt (name, def_ty, def) =
+        Format.fprintf fmt "@[<2>@[rec %a@ :=@]@ @[%a;@]@]" pp_name_ann (name, def_ty) (pp_tm names) def
+      in
+      Format.fprintf fmt "let ";
+      List.iter (fun def -> pp_fun fmt def) funs;
+      pp_tm names fmt body
+  | FunLit (name, param_ty, body) ->
+      Format.fprintf fmt "@[<2>@[fun@ %a@ =>@]@ %a@]"
+        pp_param (name, param_ty)
+        (pp_tm (name :: names)) body
+  | tm -> pp_if_tm names fmt tm
+and pp_if_tm names fmt tm =
+  match tm with
+  | BoolElim (head, tm0, tm1) ->
+      Format.fprintf fmt "@[if@ %a@ then@]@ %a@ else@ %a"
+        (pp_eq_tm names) head
+        (pp_eq_tm names) tm0
+        (pp_if_tm names) tm1
+  | tm ->
+      pp_eq_tm names fmt tm
+and pp_eq_tm names fmt tm =
+  match tm with
+  | PrimApp (`Eq, [arg1; arg2]) ->
+      Format.fprintf fmt "@[%a@ =@ %a@]"
+        (pp_add_tm names) arg1
+        (pp_eq_tm names) arg2
+  | tm ->
+      pp_add_tm names fmt tm
+and pp_add_tm names fmt tm =
+  match tm with
+  | PrimApp (`Add, [arg1; arg2]) ->
+      Format.fprintf fmt "@[%a@ +@ %a@]"
+        (pp_mul_tm names) arg1
+        (pp_add_tm names) arg2
+  | PrimApp (`Sub, [arg1; arg2]) ->
+      Format.fprintf fmt "@[%a@ -@ %a@]"
+        (pp_mul_tm names) arg1
+        (pp_add_tm names) arg2
+  | tm ->
+      pp_mul_tm names fmt tm
+and pp_mul_tm names fmt tm =
+  match tm with
+  | PrimApp (`Mul, [arg1; arg2]) ->
+      Format.fprintf fmt "@[%a@ *@ %a@]"
+        (pp_app_tm names) arg1
+        (pp_mul_tm names) arg2
+  | tm ->
+      pp_app_tm names fmt tm
+and pp_app_tm names fmt tm =
+  match tm with
+  | FunApp (head, arg) ->
+      Format.fprintf fmt "@[%a@ %a@]"
+        (pp_app_tm names) head
+        (pp_atomic_tm names) arg
+  | PrimApp (`Neg, [arg]) ->
+      Format.fprintf fmt "@[-%a@]"
+        (pp_atomic_tm names) arg
+  | tm ->
+      pp_atomic_tm names fmt tm
+and pp_atomic_tm names fmt tm =
+  match tm with
+  | Var index -> Format.fprintf fmt "%s" (List.nth names index)
+  | BoolLit true -> Format.fprintf fmt "true"
+  | BoolLit false -> Format.fprintf fmt "false"
+  | IntLit i -> Format.fprintf fmt "%i" i
+  (* FIXME: Will loop forever on invalid primitive applications *)
+  | tm -> Format.fprintf fmt "@[(%a)@]" (pp_tm names) tm

--- a/elab-stlc-letrec/Lexer.ml
+++ b/elab-stlc-letrec/Lexer.ml
@@ -1,0 +1,57 @@
+exception Error of [
+  | `UnexpectedChar
+  | `UnclosedBlockComment
+]
+
+let whitespace = [%sedlex.regexp? Plus (' ' | '\t' | '\r' | '\n')]
+let newline = [%sedlex.regexp? '\r' | '\n' | "\r\n"]
+let digits = [%sedlex.regexp? Plus ('0'..'9')]
+
+let name_start = [%sedlex.regexp? 'a'..'z' | 'A'..'Z']
+let name_continue = [%sedlex.regexp? '-' | '_' | 'a'..'z' | 'A'..'Z' | '0'..'9']
+let name = [%sedlex.regexp? name_start, Star name_continue]
+
+let rec token (lexbuf : Sedlexing.lexbuf) : Parser.token =
+  match%sedlex lexbuf with
+  | whitespace    -> token lexbuf
+  | "--"          -> line_comment lexbuf
+  | "/-"          -> block_comment lexbuf 0
+  | digits        -> NUMBER (int_of_string (Sedlexing.Utf8.lexeme lexbuf))
+  | "else"        -> KEYWORD_ELSE
+  | "false"       -> KEYWORD_FALSE
+  | "fun"         -> KEYWORD_FUN
+  | "if"          -> KEYWORD_IF
+  | "let"         -> KEYWORD_LET
+  | "rec"         -> KEYWORD_REC
+  | "then"        -> KEYWORD_THEN
+  | "true"        -> KEYWORD_TRUE
+  | name          -> NAME (Sedlexing.Utf8.lexeme lexbuf)
+  | "+"           -> ADD
+  | "*"           -> ASTERISK
+  | ":"           -> COLON
+  | ":="          -> COLON_EQUALS
+  | "="           -> EQUALS
+  | "=>"          -> EQUALS_GREATER
+  | "-"           -> HYPHEN
+  | "->"          -> HYPHEN_GREATER
+  | ";"           -> SEMICOLON
+  | "_"           -> UNDERSCORE
+  | "("           -> OPEN_PAREN
+  | ")"           -> CLOSE_PAREN
+  | eof           -> END
+  | _             -> raise (Error `UnexpectedChar)
+
+and line_comment (lexbuf : Sedlexing.lexbuf) : Parser.token =
+  match%sedlex lexbuf with
+  | newline       -> token lexbuf
+  | any           -> line_comment lexbuf
+  | eof           -> END
+  | _             -> raise (Error `UnexpectedChar)
+
+and block_comment (lexbuf : Sedlexing.lexbuf) (level : int) : Parser.token =
+  match%sedlex lexbuf with
+  | "/-"          -> block_comment lexbuf (level + 1)
+  | "-/"          -> if level = 0 then token lexbuf else block_comment lexbuf (level - 1)
+  | any           -> block_comment lexbuf level
+  | eof           -> raise (Error `UnclosedBlockComment)
+  | _             -> raise (Error `UnexpectedChar)

--- a/elab-stlc-letrec/Main.ml
+++ b/elab-stlc-letrec/Main.ml
@@ -1,0 +1,63 @@
+(** {0 Elaborator CLI} *)
+
+(** {1 Helper functions} *)
+
+let print_error (start, _ : Surface.loc) message =
+  Printf.eprintf "%s:%d:%d: %s\n"
+    start.pos_fname
+    start.pos_lnum
+    (start.pos_cnum - start.pos_bol)
+    message
+
+
+(** {1 Main entrypoint} *)
+
+let () =
+  Printexc.record_backtrace true;
+
+  let tm =
+    let lexbuf = Sedlexing.Utf8.from_channel stdin in
+    Sedlexing.set_filename lexbuf "<input>";
+
+    try
+      lexbuf
+      |> Sedlexing.with_tokenizer Lexer.token
+      |> MenhirLib.Convert.Simplified.traditional2revised Parser.main
+    with
+    | Lexer.Error error ->
+        let msg =
+          match error with
+          | `UnexpectedChar -> "unexpected character"
+          | `UnclosedBlockComment -> "unclosed block comment"
+        in
+        print_error (Sedlexing.lexing_positions lexbuf) msg;
+        exit 1
+    | Parser.Error ->
+        print_error (Sedlexing.lexing_positions lexbuf) "syntax error";
+        exit 1
+  in
+
+  let tm, ty =
+    try Surface.elab_infer [] tm with
+    | Surface.Error (pos, msg) ->
+        print_error pos msg;
+        exit 1
+  in
+
+  match Surface.unsolved_metas () with
+  | [] ->
+      let tm = (Core.zonk_tm tm) in
+      let ty = (Core.zonk_ty ty) in
+      Format.printf "@[<2>@[%a@ :@]@ @[%a@]@]@."
+        (Core.pp_tm []) tm
+        Core.pp_ty ty;
+      let vtm = Core.Semantics.eval [] tm in
+      let tm = Core.Semantics.quote 0 vtm in
+      Format.printf "%a" (Core.pp_tm []) tm
+  | unsolved_metas ->
+      unsolved_metas |> List.iter (function
+        | (pos, `FunParam) -> print_error pos "ambiguous function parameter type"
+        | (pos, `FunBody) -> print_error pos "ambiguous function return type"
+        | (pos, `IfBranches) -> print_error pos "ambiguous if expression branches"
+        | (pos, `Placeholder) -> print_error pos "unsolved placeholder");
+      exit 1

--- a/elab-stlc-letrec/Parser.mly
+++ b/elab-stlc-letrec/Parser.mly
@@ -1,0 +1,111 @@
+%token <string> NAME
+%token <int> NUMBER
+%token KEYWORD_ELSE "else"
+%token KEYWORD_FALSE "false"
+%token KEYWORD_FUN "fun"
+%token KEYWORD_IF "if"
+%token KEYWORD_LET "let"
+%token KEYWORD_REC "rec"
+%token KEYWORD_THEN "then"
+%token KEYWORD_TRUE "true"
+%token ADD "+"
+%token ASTERISK "*"
+%token COLON ":"
+%token COLON_EQUALS ":="
+%token EQUALS "="
+%token EQUALS_GREATER "=>"
+%token HYPHEN "-"
+%token HYPHEN_GREATER "->"
+%token SEMICOLON ";"
+%token UNDERSCORE "_"
+%token OPEN_PAREN "("
+%token CLOSE_PAREN ")"
+%token END
+
+%start <Surface.tm> main
+
+%%
+
+let main :=
+| tm = located(tm); END;
+    { tm }
+
+let located(X) :=
+| data = X;
+    { Surface.{ loc = $loc; data } }
+
+let binder :=
+| located(NAME)
+
+let letrec_def :=
+| "rec"; n = binder; params = list(param); ty = option(":"; located(ty)); ":="; tm = located(tm); ";";
+    { n, params, ty, tm }
+
+let param :=
+| n = binder;
+    { n, None }
+| "("; n = binder; ":"; ty = located(ty); ")";
+    { n, Some ty }
+
+let ty :=
+| ty1 = located(atomic_ty); "->"; ty2 = located(ty);
+    { Surface.FunType (ty1, ty2) }
+| atomic_ty
+
+let atomic_ty :=
+| "("; ty = ty; ")";
+    { ty }
+| n = NAME;
+    { Surface.Name n }
+| UNDERSCORE;
+    { Surface.Placeholder }
+
+let tm :=
+| "let"; defs = nonempty_list(letrec_def); body = located(tm);
+    { Surface.LetRec (defs, body) }
+| "let"; n = binder; ps = list(param); ty = option(":"; ty = located(ty); { ty }); ":=";
+    tm0 = located(tm); ";"; tm1 = located(tm);
+    { Surface.Let (n, ps, ty, tm0, tm1) }
+| "fun"; ps = nonempty_list(param); "=>"; t = located(tm);
+    { Surface.FunLit (ps, t) }
+| "if"; tm0 = located(eq_tm); "then"; tm1 = located(tm); "else"; tm2 = located(tm);
+    { Surface.IfThenElse (tm0, tm1, tm2) }
+| tm = located(eq_tm); ":"; ty = located(ty);
+    { Surface.Ann (tm, ty) }
+| eq_tm
+
+let eq_tm :=
+| tm0 = located(add_tm); "="; tm1 = located(eq_tm);
+    { Surface.Op2 (`Eq, tm0, tm1) }
+| add_tm
+
+let add_tm :=
+| tm0 = located(mul_tm); "+"; tm1 = located(add_tm);
+    { Surface.Op2 (`Add, tm0, tm1) }
+| tm0 = located(mul_tm); "-"; tm1 = located(add_tm);
+    { Surface.Op2 (`Sub, tm0, tm1) }
+| mul_tm
+
+let mul_tm :=
+| tm0 = located(app_tm); "*"; tm1 = located(mul_tm);
+    { Surface.Op2 (`Mul, tm0, tm1) }
+| app_tm
+
+let app_tm :=
+| tm0 = located(app_tm); tm1 = located(atomic_tm);
+    { Surface.FunApp (tm0, tm1) }
+| "-"; tm = located(atomic_tm);
+    { Surface.Op1 (`Neg, tm) }
+| atomic_tm
+
+let atomic_tm :=
+| "("; tm = tm; ")";
+    { tm }
+| n = NAME;
+    { Surface.Name n }
+| "true";
+    { Surface.BoolLit true }
+| "false";
+    { Surface.BoolLit false }
+| i = NUMBER;
+    { Surface.IntLit i }

--- a/elab-stlc-letrec/README.md
+++ b/elab-stlc-letrec/README.md
@@ -1,0 +1,47 @@
+# Simply typed lambda calculus with unification
+
+This an elaborator for a simply typed lambda calculus (with booleans and integers)
+that allows programmers to omit type annotations. This is done by inserting
+_metavariables_ that stand-in for unknown types during elaboration. These are
+later updated based on how they are used in other parts of the program.
+
+This approach is a stepping-stone to more powerful type checking algorithms,
+such as those for Hindley-Milner type systems. Note that it’s not a highly
+optimised implementation – the goal here is clarity.
+
+This implementation was originally based on [Arad Arbel’s gist](https://gist.github.com/aradarbel10/837aa65d2f06ac6710c6fbe479909b4c).
+
+## Project overview
+
+| Module        | Description                             |
+| ------------- | --------------------------------------- |
+| [`Main`]      | Command line interface                  |
+| [`Lexer`]     | Lexer for the surface language          |
+| [`Parser`]    | Parser for the surface language         |
+| [`Surface`]   | Surface language, including elaboration |
+| [`Core`]      | Core language, including normalisation, unification, and pretty printing |
+
+[`Main`]: ./Main.ml
+[`Lexer`]: ./Lexer.mll
+[`Parser`]: ./Parser.mly
+[`Surface`]: ./Surface.ml
+[`Core`]: ./Core.ml
+
+## Examples
+
+```sh
+$ stlc-unification <<< "fun x => x + 2"
+fun (x : Int) => x + 2 : Int -> Int
+```
+
+```sh
+$ stlc-unification <<< "fun x f => f x * x"
+fun (x : Int) => fun (f : Int -> Int) => f x * x : Int -> (Int -> Int) -> Int
+```
+
+```sh
+$ stlc-unification <<< "fun x y => if x = 0 then y else 3"
+fun (x : Int) => fun (y : Int) => if x = 0 then y else 3 : Int -> Int -> Int
+```
+
+More examples can be found in [`tests.t`](tests.t).

--- a/elab-stlc-letrec/Surface.ml
+++ b/elab-stlc-letrec/Surface.ml
@@ -1,0 +1,268 @@
+(** {0 Surface language}
+
+    The surface language closely mirrors what the programmer originaly wrote,
+    including syntactic sugar and higher level language features that make
+    programming more convenient (in comparison to the {!Core}).
+*)
+
+(** {1 Syntax} *)
+
+(** The start and end position in a source file *)
+type loc =
+  Lexing.position * Lexing.position
+
+(** Located nodes *)
+type 'a located = {
+  loc : loc;
+  data : 'a;
+}
+
+(** Types in the surface language *)
+type ty =
+  ty_data located
+
+and ty_data =
+  | Name of string
+  | FunType of ty * ty
+  | Placeholder
+
+(** Names that bind definitions or parameters *)
+type binder = string located
+
+(** Terms in the surface language *)
+type tm =
+  tm_data located
+
+and tm_data =
+  | Name of string
+  | Let of binder * param list * ty option * tm * tm
+  | LetRec of (binder * param list * ty option * tm) list * tm
+  | Ann of tm * ty
+  | BoolLit of bool
+  | IfThenElse of tm * tm * tm
+  | IntLit of int
+  | FunLit of param list * tm
+  | FunApp of tm * tm
+  | Op2 of [`Eq | `Add | `Sub | `Mul] * tm * tm
+  | Op1 of [`Neg] * tm
+
+(** Parameters, with optional type annotations *)
+and param =
+  binder * ty option
+
+
+(** {1 Elaboration} *)
+
+(** This is where we implement user-facing type checking, while also translating
+    the surface language into the simpler, more explicit core language.
+
+    While we {e could} translate syntactic sugar in the parser, by leaving
+    this to elaboration time we make it easier to report higher quality error
+    messages that are more relevant to what the programmer originally wrote.
+*)
+
+(** {2 Metavariables} *)
+
+(** The reason why a metavariable was inserted *)
+type meta_info = [
+  | `FunParam
+  | `FunBody
+  | `IfBranches
+  | `Placeholder
+]
+
+(** A global list of the metavariables inserted during elaboration. This is used
+    to generate a list of unsolved metavariables at the end of elaboration. *)
+let metas : (loc * meta_info * Core.meta_state ref) list ref = ref []
+
+(** Generate a fresh metavariable, recording it in the list of metavariables *)
+let fresh_meta (loc: loc) (info : meta_info) : Core.ty =
+  let state = Core.fresh_meta () in
+  metas := (loc, info, state) :: !metas;
+  MetaVar state
+
+(** Return a list of unsolved metavariables *)
+let unsolved_metas () : (loc * meta_info) list =
+  let rec go acc metas =
+    match metas with
+    | [] -> acc
+    | (loc, info, m) :: metas -> begin
+        match !m with
+        | Core.Unsolved _ -> go ((loc, info) :: acc) metas
+        | Core.Solved _ -> go acc metas
+    end
+  in
+  go [] !metas
+
+
+(** {2 Local bindings} *)
+
+(** A stack of bindings currently in scope *)
+type context = (string * Core.ty) Core.env
+
+(** Lookup a name in the context *)
+let lookup (context : context) (name : string) : (Core.index * Core.ty) option =
+  let rec go index context =
+    match context with
+    | (name', ty) :: _ when name = name' -> Some (index, ty)
+    | (_, _) :: context -> go (index + 1) context
+    | [] -> None
+  in
+  go 0 context
+
+
+(** {2 Elaboration errors} *)
+
+(** An error that will be raised if there was a problem in the surface syntax,
+    usually as a result of type errors. This is normal, and should be rendered
+    nicely to the programmer. *)
+exception Error of loc * string
+
+(** Raises an {!Error} exception *)
+let error (loc : loc) (message : string) : 'a =
+  raise (Error (loc, message))
+
+let unify (loc : loc) (ty1 : Core.ty) (ty2 : Core.ty) =
+  try Core.unify ty1 ty2 with
+  | Core.InfiniteType _ -> error loc "infinite type"
+  | Core.MismatchedTypes (_, _) ->
+      error loc
+        (Format.asprintf "@[<v 2>@[mismatched types:@]@ @[expected: %a@]@ @[found: %a@]@]"
+          Core.pp_ty (Core.zonk_ty ty1)
+          Core.pp_ty (Core.zonk_ty ty2))
+
+(** {2 Type checking} *)
+
+(** Elaborate a type, checking that it is well-formed. *)
+let rec elab_ty (ty : ty) : Core.ty =
+  match ty.data with
+  | Name "Bool" -> BoolType
+  | Name "Int" -> IntType
+  | Name name ->
+      error ty.loc (Format.asprintf "unbound type `%s`" name)
+  | FunType (ty1, ty2) ->
+      FunType (elab_ty ty1, elab_ty ty2)
+  | Placeholder ->
+      fresh_meta ty.loc `Placeholder
+
+(** In this algorithm type checking is mainly unidirectional, relying on the
+    [infer] funtion, but a {!check} function is provided for convenience.
+*)
+
+(** Elaborate a surface term into a core term, given an expected type. *)
+let rec elab_check (context : context) (tm : tm) (ty : Core.ty) : Core.tm =
+  let tm', ty' = elab_infer context tm in
+  unify tm.loc ty ty';
+  tm'
+
+(** Elaborate a surface term into a core term, inferring its type. *)
+and elab_infer (context : context) (tm : tm) : Core.tm * Core.ty =
+  match tm.data with
+  | Name name -> begin
+      match lookup context name with
+      | Some (index, ty) -> Var index, ty
+      | None -> error tm.loc (Format.asprintf "unbound name `%s`" name)
+  end
+  | Let (def_name, params, def_body_ty, def_body, body) ->
+      let def, def_ty = elab_infer_fun_lit context params def_body_ty def_body in
+      let body, body_ty = elab_infer ((def_name.data, def_ty) :: context) body in
+      Let (def_name.data, def_ty, def, body), body_ty
+  | Ann (tm, ty) ->
+      let ty = elab_ty ty in
+      elab_check context tm ty, ty
+  | BoolLit b -> BoolLit b, BoolType
+  | IfThenElse (head, tm0, tm1) ->
+      let head = elab_check context head BoolType in
+      let ty = fresh_meta tm.loc `IfBranches in
+      let tm0 = elab_check context tm0 ty in
+      let tm1 = elab_check context tm1 ty in
+      BoolElim (head, tm0, tm1), ty
+  | IntLit i -> IntLit i, IntType
+  | FunLit (params, body) ->
+      elab_infer_fun_lit context params None body
+  | FunApp (head, arg) ->
+      let head_loc = head.loc in
+      let head, head_ty = elab_infer context head in
+      let param_ty, body_ty =
+        match head_ty with
+        | FunType (param_ty, body_ty) -> param_ty, body_ty
+        | head_ty ->
+            let param_ty = fresh_meta head_loc `FunParam in
+            let body_ty = fresh_meta head_loc `FunBody in
+            unify head_loc head_ty (FunType (param_ty, body_ty));
+            param_ty, body_ty
+      in
+      let arg = elab_check context arg param_ty in
+      FunApp (head, arg), body_ty
+  | Op2 ((`Eq) as prim, tm0, tm1) ->
+      let tm0 = elab_check context tm0 IntType in
+      let tm1 = elab_check context tm1 IntType in
+      PrimApp (prim, [tm0; tm1]), BoolType
+  | Op2 ((`Add | `Sub | `Mul) as prim, tm0, tm1) ->
+      let tm0 = elab_check context tm0 IntType in
+      let tm1 = elab_check context tm1 IntType in
+      PrimApp (prim, [tm0; tm1]), IntType
+  | Op1 ((`Neg) as prim, tm) ->
+      let tm = elab_check context tm IntType in
+      PrimApp (prim, [tm]), IntType
+  | LetRec (defs, body) ->
+      let context' = ListLabels.map defs ~f:(fun(name, params, ty, _) -> (name.data, elab_infer_fun_signature context name.loc params ty)) in
+      let context = List.append context context' in
+      let funs = ListLabels.map2 defs context' ~f:(fun(_name, params, _ty, expr) (name, ty) ->
+        let core_expr = elab_check_fun_lit context params expr ty in
+        match core_expr with
+        | FunLit _ -> (name, ty, core_expr)
+        | _ -> error expr.loc "RHS of let rec must be function literal"
+      ) in
+      let body, body_ty = elab_infer context body in
+      Fix(funs, body), body_ty
+
+(** Elaborate a function literal, inferring its type. *)
+and elab_infer_fun_lit (context : context) (params : param list) (body_ty : ty option) (body : tm) : Core.tm * Core.ty =
+  match params, body_ty with
+  | [], Some body_ty ->
+      let body_ty = elab_ty body_ty in
+      elab_check context body body_ty, body_ty
+  | [], None ->
+      elab_infer context body
+  | (name, param_ty) :: params, body_ty ->
+      let param_ty = match param_ty with
+        | None -> fresh_meta name.loc `FunParam
+        | Some ty -> elab_ty ty
+      in
+      let body, body_ty = elab_infer_fun_lit ((name.data, param_ty) :: context) params body_ty body in
+      FunLit (name.data, param_ty, body), FunType (param_ty, body_ty)
+
+(** Elaborate a function literal, checking its type. *)
+and elab_check_fun_lit (context : context) (params : param list) (body : tm) (body_ty: Core.ty) : Core.tm  =
+  match params, body_ty with
+  | [], body_ty -> elab_check context body body_ty
+  | (name, Some(param_ty)) :: params, FunType(expected_param_ty, body_ty) ->
+      let param_ty = elab_check_param_ty param_ty expected_param_ty in
+      let body = elab_check_fun_lit ((name.data, param_ty) :: context) params body body_ty in
+      FunLit (name.data, param_ty, body)
+  | (name, None) :: params, FunType(param_ty, body_ty) ->
+      let body = elab_check_fun_lit ((name.data, param_ty) :: context) params body body_ty in
+      FunLit (name.data, param_ty, body)
+  | (name, _) :: _, _ -> error name.loc "expected function"
+
+and elab_check_param_ty (ty: ty) (expected: Core.ty): Core.ty =
+  let param_ty = elab_ty ty in
+  unify ty.loc param_ty expected;
+  expected
+
+(** Elaborate a function signature, inferring its type. *)
+and elab_infer_fun_signature (context : context) (loc : loc) (params : param list) (body_ty : ty option) : Core.ty =
+  match params, body_ty with
+  | [], Some body_ty ->
+      let body_ty = elab_ty body_ty in
+      body_ty
+  | [], None ->
+      fresh_meta loc `FunBody
+  | (name, param_ty) :: params, body_ty ->
+      let param_ty = match param_ty with
+        | None -> fresh_meta name.loc `FunParam
+        | Some ty -> elab_ty ty
+      in
+      let body_ty = elab_infer_fun_signature ((name.data, param_ty) :: context) loc params body_ty in
+      FunType (param_ty, body_ty)

--- a/elab-stlc-letrec/dune
+++ b/elab-stlc-letrec/dune
@@ -1,0 +1,20 @@
+(executable
+  (name Main)
+  (public_name stlc-letrec)
+  (package elab-stlc-letrec)
+  (preprocess
+    (pps sedlex.ppx))
+  (libraries
+    menhirLib))
+
+(menhir
+  (modules Parser)
+  (flags --explain --strict))
+
+(mdx
+  (package elab-stlc-letrec)
+  (deps %{bin:stlc-letrec}))
+
+(cram
+  (package elab-stlc-letrec)
+  (deps %{bin:stlc-letrec}))

--- a/elab-stlc-letrec/tests.t
+++ b/elab-stlc-letrec/tests.t
@@ -1,0 +1,124 @@
+Addition
+  $ stlc-letrec <<< "1 + 2"
+  1 + 2 : Int
+
+Add two function
+  $ stlc-letrec <<< "fun x => x + 2"
+  fun (x : Int) => x + 2 : Int -> Int
+
+Function application
+  $ stlc-letrec <<< "fun x f => f x * x"
+  fun (x : Int) => fun (f : Int -> Int) => f x * x : Int -> (Int -> Int) -> Int
+
+Function application
+  $ stlc-letrec <<< "let f x := x; f 3"
+  let f : Int -> Int := fun (x : Int) => x; f 3 : Int
+
+Explicit parameter type
+  $ stlc-letrec <<< "let f (x : Int) := x; f 3"
+  let f : Int -> Int := fun (x : Int) => x; f 3 : Int
+
+Explicit return type
+  $ stlc-letrec <<< "let f (x : Int) : Int := x; f 3"
+  let f : Int -> Int := fun (x : Int) => x; f 3 : Int
+
+Placeholder types
+  $ stlc-letrec <<< "let f (x : _) : _ := x; f 3"
+  let f : Int -> Int := fun (x : Int) => x; f 3 : Int
+
+If expressions
+  $ stlc-letrec <<< "fun x y => if x = 0 then y else 3"
+  fun (x : Int) => fun (y : Int) => if x = 0 then y else 3 : Int -> Int -> Int
+
+letrec expressions
+  $ stlc-letrec <<< "let rec fact n := if n = 0 then 1 else n * fact (n - 1); fact 5"
+  let rec fact : Int -> Int :=
+        fun (n : Int) => if n = 0 then 1 else n * fact (n - 1);fact 5
+  : Int
+
+# FIXME: hangs
+#  $ stlc-letrec <<< "let rec fact n := if n = 0 then 1 else n * fact (n - 1); fact"
+#  let rec fact : Int -> Int :=
+#        fun (n : Int) => if n = 0 then 1 else n * fact (n - 1);fact
+#  : Int -> Int
+
+Lexer Errors
+------------
+
+Unexpected character
+  $ stlc-letrec <<< "1 % 2"
+  <input>:1:2: unexpected character
+  [1]
+
+Unclosed block comment
+  $ stlc-letrec <<< "/- hellooo"
+  <input>:2:0: unclosed block comment
+  [1]
+
+
+Parse Errors
+------------
+
+Unclosed parenthesis
+  $ stlc-letrec <<< "1 + (3 "
+  <input>:2:0: syntax error
+  [1]
+
+
+
+Elaboration Errors
+------------------
+
+Unbound variable
+  $ stlc-letrec <<< "let x := 1; y"
+  <input>:1:12: unbound name `y`
+  [1]
+
+Mismatched definition type
+  $ stlc-letrec <<< "let x : Bool := 1; x"
+  <input>:1:16: mismatched types:
+    expected: Bool
+    found: Int
+  [1]
+
+Mismatched argument
+  $ stlc-letrec <<< "let f x := x + 1; f f"
+  <input>:1:20: mismatched types:
+    expected: Int
+    found: Int -> Int
+  [1]
+
+Mismatched argument
+  $ stlc-letrec <<< "let f (x : Bool) := x; f 1"
+  <input>:1:25: mismatched types:
+    expected: Bool
+    found: Int
+  [1]
+
+Infinite type
+  $ stlc-letrec <<< "fun f => f f"
+  <input>:1:11: infinite type
+  [1]
+
+Ambiguous parameter type
+  $ stlc-letrec <<< "fun x => x"
+  <input>:1:4: ambiguous function parameter type
+  [1]
+
+Ambiguous return type
+  $ stlc-letrec <<< "fun f x => f x"
+  <input>:1:6: ambiguous function parameter type
+  <input>:1:11: ambiguous function return type
+  [1]
+
+Ambiguous placeholder
+  $ stlc-letrec <<< "fun (x : _) => x"
+  <input>:1:9: unsolved placeholder
+  [1]
+
+Mismatched if expression branches
+  $ stlc-letrec <<< "fun x => if x then true else 3"
+  <input>:1:29: mismatched types:
+    expected: Bool
+    found: Int
+  [1]


### PR DESCRIPTION
Adds recursive let:

```
let rec x1 = e1;
    rec x2 = e2;
    ...
    rec xn = en;
e
```
Each RHS must elaborate to a function literal. This restriction could be loosened using a more sophisticated check like in https://arxiv.org/pdf/1811.08134.pdf.

Evaluation is done by piggy-backing off the host language's `let rec` feature, as detailed in https://www.cs.princeton.edu/courses/archive/spr96/cs441/notes/l6.html.

This implementation is still unfinished:
I modified the repl to eval the expression, and then quote back the value and print it, to check that evaluation is correct.
Evaluation itself is indeed correct, but quoting back the resulting value hangs: 
`let rec fact n = if n = 0 then 1 else n * fact (n - 1); fact` hangs

I believe this is because `quote` explores both the recursive and base cases `fact`'s body (ie both branches of the `if`). I probably need to add a mechanism to stop unfolding of recursive functions during quoting.

Apologies if it is not idiomatic OCaml - this is my first time using the language