### PR TITLE
Fix substitution bugs in the named and nameless interpreters

### DIFF
--- a/lang-lc-interpreters/named.ml
+++ b/lang-lc-interpreters/named.ml
@@ -84,11 +84,11 @@ let rec subst (x, s : string * expr) (e : expr) : expr =
   let rec go e =
     match e with
     | Var y -> if x = y then s else e
-    | Let (y, _, _) when x = y -> e
+    | Let (y, def, body) when x = y -> Let (y, go def, body)
     | Let (y, def, body) when String_set.mem y fvs ->
         let y', body' = freshen_body y body in
         Let (y', go def, go body')
-    | Let (y, def, body) -> Let (y, def, go body)
+    | Let (y, def, body) -> Let (y, go def, go body)
     | Fun_lit (y, _) when x = y -> e
     | Fun_lit (y, body) when String_set.mem y fvs ->
         let y', body' = freshen_body y body in

--- a/lang-lc-interpreters/nameless.ml
+++ b/lang-lc-interpreters/nameless.ml
@@ -86,7 +86,7 @@ let shift (diff : int) (e : expr) : expr =
   map_vars (fun size i -> if i >= size then Var (i + diff) else Var i) 0 e
 
 let subst (i, s : int * expr) (e : expr) : expr =
-  map_vars (fun size j -> if i = j + size then shift size s else e) 0 e
+  map_vars (fun size j -> if j = i + size then shift size s else Var j) 0 e
 
 let subst_top (s : expr) (e : expr) : expr =
   shift (-1) (subst (0, shift 1 s) e)


### PR DESCRIPTION
Nameless.subst had an inverted index comparison (the rule is j = i + size, not i = j + size) and its fallback branch returned the whole expression being substituted into, rather than the variable, so every non-matching variable under a binder was replaced by a copy of the entire term. Normalising `fun a => (fun x => fun y => x) a` produced `fun a => fun y => fun y' => y` instead of `fun a => fun y => a`, and substitutions into let bindings diverged.

Named.subst skipped let definitions in two of its three let cases, even though the definition is outside the binder's scope, so `(fun x => let y := x; y) a` normalised to a free `x` instead of `a`. The shadowing case must also still substitute into the definition. The freshening case in between already handled this correctly.